### PR TITLE
update to 251

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
 
+    - name: Run standardrb
+      run: bundle exec standardrb --no-fix
+
     - name: Run tests
       timeout-minutes: 5
-      run: ${{matrix.env}} bundle exec rake
+      run: ${{matrix.env}} bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         - ruby: "truffleruby"
           experimental: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,16 @@
 # connection_pool Changelog
 
+2.5.0
+------
+
+- Reap idle connections [#187]
+```ruby
+idle_timeout = 60
+pool = ConnectionPool.new ...
+pool.reap(idle_timeout, &:close)
+```
+- `ConnectionPool#idle` returns the count of connections not in use [#187]
+
 2.4.1
 ------
 

--- a/lib/connection_pool.rb
+++ b/lib/connection_pool.rb
@@ -160,6 +160,12 @@ class ConnectionPool
     @available.shutdown(reload: true, &block)
   end
 
+  ## Reaps idle connections that have been idle for over +idle_seconds+.
+  # +idle_seconds+ defaults to 60.
+  def reap(idle_seconds = 60, &block)
+    @available.reap(idle_seconds, &block)
+  end
+
   # Size of this connection pool
   attr_reader :size
   # Automatically drop all connections after fork
@@ -168,6 +174,11 @@ class ConnectionPool
   # Number of pool entries available for checkout at this instant.
   def available
     @available.length
+  end
+
+  # Number of pool entries created and idle in the pool.
+  def idle
+    @available.idle
   end
 end
 

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -114,10 +114,16 @@ class ConnectionPool::TimedStack
     raise ArgumentError, "reap must receive a block" unless block
     raise ArgumentError, "idle_seconds must be a number" unless idle_seconds.is_a?(Numeric)
 
-    @mutex.synchronize do
-      reap_start_time = current_time
+    loop do
+      conn =
+        @mutex.synchronize do
+          raise ConnectionPool::PoolShuttingDownError if @shutdown_block
 
-      reap_idle_connections(idle_seconds, reap_start_time, &block)
+          reserve_idle_connection(idle_seconds)
+        end
+      break unless conn
+
+      block.call(conn)
     end
   end
 
@@ -179,14 +185,16 @@ class ConnectionPool::TimedStack
   ##
   # This is an extension point for TimedStack and is called with a mutex.
   #
-  # This method iterates over the connections in the stack and reaps the oldest idle connections one at a time until
-  # the first connection is not idle. This requires that the stack is kept in order of checked in time (oldest first).
+  # This method returns the oldest idle connection if it has been idle for more than idle_seconds.
+  # This requires that the stack is kept in order of checked in time (oldest first).
 
-  def reap_idle_connections(idle_seconds, reap_start_time, &reap_block)
-    while idle_connections?(idle_seconds, reap_start_time)
-      conn, _last_checked_out = @que.shift
-      reap_block.call(conn)
-    end
+  def reserve_idle_connection(idle_seconds)
+    return unless idle_connections?(idle_seconds)
+
+    # Decrement created unless this is a no create stack
+    @created -= 1 unless @max == 0
+
+    @que.shift.first
   end
 
   ##
@@ -194,11 +202,8 @@ class ConnectionPool::TimedStack
   #
   # Returns true if the first connection in the stack has been idle for more than idle_seconds
 
-  def idle_connections?(idle_seconds, reap_start_time)
-    if connection_stored?
-      _conn, last_checked_out = @que.first
-      reap_start_time - last_checked_out > idle_seconds
-    end
+  def idle_connections?(idle_seconds)
+    connection_stored? && (current_time - @que.first.last > idle_seconds)
   end
 
   ##

--- a/lib/connection_pool/timed_stack.rb
+++ b/lib/connection_pool/timed_stack.rb
@@ -113,8 +113,9 @@ class ConnectionPool::TimedStack
   def reap(idle_seconds, &block)
     raise ArgumentError, "reap must receive a block" unless block
     raise ArgumentError, "idle_seconds must be a number" unless idle_seconds.is_a?(Numeric)
+    raise ConnectionPool::PoolShuttingDownError if @shutdown_block
 
-    loop do
+    idle.times do
       conn =
         @mutex.synchronize do
           raise ConnectionPool::PoolShuttingDownError if @shutdown_block

--- a/lib/connection_pool/version.rb
+++ b/lib/connection_pool/version.rb
@@ -1,3 +1,3 @@
 class ConnectionPool
-  VERSION = "2.4.1"
+  VERSION = "2.5.0"
 end

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -535,6 +535,16 @@ class TestConnectionPool < Minitest::Test
     assert_equal 3, pool.idle
   end
 
+  def test_reap_raises_error_after_shutting_down
+    pool = ConnectionPool.new(size: 1) { true }
+
+    pool.shutdown {}
+
+    assert_raises ConnectionPool::PoolShuttingDownError do
+      pool.reap(0) {}
+    end
+  end
+
   def test_wrapper_wrapped_pool
     wrapper = ConnectionPool::Wrapper.new { NetworkConnection.new }
     assert_equal ConnectionPool, wrapper.wrapped_pool.class

--- a/test/test_connection_pool.rb
+++ b/test/test_connection_pool.rb
@@ -407,6 +407,17 @@ class TestConnectionPool < Minitest::Test
     assert_equal [["shutdown"]] * 3, recorders.map { |r| r.calls }
   end
 
+  def test_checkout_after_reload_cannot_create_new_connections_beyond_size
+    pool = ConnectionPool.new(size: 1) { Object.new }
+    threads = use_pool pool, 1
+    pool.reload {}
+    assert_raises ConnectionPool::TimeoutError do
+      pool.checkout(timeout: 0)
+    end
+  ensure
+    kill_threads(threads) if threads
+  end
+
   def test_raises_error_after_shutting_down
     pool = ConnectionPool.new(size: 1) { true }
 

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -33,6 +33,27 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_equal 1, stack.length
   end
 
+  def test_length_after_shutdown_reload_for_no_create_stack
+    assert_equal 0, @stack.length
+
+    @stack.push(Object.new)
+
+    assert_equal 1, @stack.length
+
+    @stack.shutdown(reload: true) {}
+
+    assert_equal 0, @stack.length
+  end
+
+  def test_length_after_shutdown_reload_with_checked_out_conn
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    conn = stack.pop
+    stack.shutdown(reload: true) {}
+    assert_equal 0, stack.length
+    stack.push(conn)
+    assert_equal 1, stack.length
+  end
+
   def test_idle
     stack = ConnectionPool::TimedStack.new(1) { Object.new }
 
@@ -94,6 +115,22 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_empty stack
   end
 
+  def test_pop_full_with_extra_conn_pushed
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    popped = stack.pop
+
+    stack.push(Object.new)
+    stack.push(popped)
+
+    assert_equal 2, stack.length
+
+    stack.shutdown(reload: true) {}
+
+    assert_equal 1, stack.length
+    stack.pop
+    assert_raises(ConnectionPool::TimeoutError) { stack.pop(0) }
+  end
+
   def test_pop_wait
     thread = Thread.start {
       @stack.pop
@@ -124,6 +161,15 @@ class TestConnectionPoolTimedStack < Minitest::Test
     stack.shutdown(reload: true) {}
 
     refute_equal object, stack.pop
+  end
+
+  def test_pop_raises_error_if_shutdown_reload_is_run_and_connection_is_still_in_use
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack.pop
+    stack.shutdown(reload: true) {}
+    assert_raises ConnectionPool::TimeoutError do
+      stack.pop(0)
+    end
   end
 
   def test_push
@@ -160,6 +206,54 @@ class TestConnectionPoolTimedStack < Minitest::Test
 
     refute_empty called
     assert_empty @stack
+  end
+
+  def test_shutdown_can_be_called_after_error
+    3.times { @stack.push Object.new }
+
+    called = []
+    closing_error = "error in closing connection"
+    raise_error = true
+    shutdown_proc = ->(conn) do
+      called << conn
+      if raise_error
+        raise_error = false
+        raise closing_error
+      end
+    end
+
+    assert_raises(closing_error) do
+      @stack.shutdown(&shutdown_proc)
+    end
+
+    assert_equal 1, called.size
+
+    @stack.shutdown(&shutdown_proc)
+    assert_equal 3, called.size
+  end
+
+  def test_reap_can_be_called_after_error
+    3.times { @stack.push Object.new }
+
+    called = []
+    closing_error = "error in closing connection"
+    raise_error = true
+    reap_proc = ->(conn) do
+      called << conn
+      if raise_error
+        raise_error = false
+        raise closing_error
+      end
+    end
+
+    assert_raises(closing_error) do
+      @stack.reap(0, &reap_proc)
+    end
+
+    assert_equal 1, called.size
+
+    @stack.reap(0, &reap_proc)
+    assert_equal 3, called.size
   end
 
   def test_reap

--- a/test/test_connection_pool_timed_stack.rb
+++ b/test/test_connection_pool_timed_stack.rb
@@ -175,6 +175,18 @@ class TestConnectionPoolTimedStack < Minitest::Test
     assert_empty @stack
   end
 
+  def test_reap_full_stack
+    stack = ConnectionPool::TimedStack.new(1) { Object.new }
+    stack.push stack.pop
+
+    stack.reap(0) do |object|
+      nil
+    end
+
+    # Can still pop from the stack after reaping all connections
+    refute_nil stack.pop
+  end
+
   def test_reap_large_idle_seconds
     @stack.push Object.new
 
@@ -250,7 +262,7 @@ class TestConnectionPoolTimedStack < Minitest::Test
     end
 
     assert_equal [conn1, conn2], called
-    assert_empty stack
+    assert_equal 0, stack.idle
   end
 
   def test_reap_with_multiple_connections_and_idle_seconds_outside_range


### PR DESCRIPTION
Changes from upstream:
- Add reap functionality (#187)
- Bump actions/checkout from 3 to 4 (#181)
- Make automatically fixable standard issues fail CI (#190)
- Avoid extra mutex contention (#189)
- ensure reap does not enter infinite loop (#193)
- Track checked out created connections across reloads (#192)
- prep for release

Our change:
- Non-blocking connection creation
